### PR TITLE
Fullscreen on release & full page web

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,8 +1,8 @@
-run:
-    cargo run --features bevy/dynamic_linking
+run *OPTIONS:
+    cargo run --features bevy/dynamic_linking {{OPTIONS}}
 
-playground:
-    cargo run --features bevy/dynamic_linking --bin playground
+playground *OPTIONS:
+    cargo run --features bevy/dynamic_linking --bin playground {{OPTIONS}}
 
-web:
-    trunk serve --open
+web *OPTIONS:
+    trunk serve --open {{OPTIONS}}

--- a/index.scss
+++ b/index.scss
@@ -1,0 +1,6 @@
+body {
+    width: 100vw;
+    height: 100vh;
+    margin: 0;
+    overflow: hidden;
+}

--- a/src/bin/playground.rs
+++ b/src/bin/playground.rs
@@ -84,7 +84,22 @@ impl Plugin for Stuff {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "Bevy Jam 3 🦀 Playground".into(),
+                mode: if cfg!(debug_assertions) {
+                    bevy::window::WindowMode::Windowed
+                } else {
+                    bevy::window::WindowMode::BorderlessFullscreen
+                },
+                // Tells wasm to resize the window according to the available canvas
+                fit_canvas_to_parent: true,
+                // Tells wasm not to override default event handling, like F5, Ctrl+R etc.
+                prevent_default_event_handling: false,
+                ..default()
+            }),
+            ..default()
+        }))
         .add_plugin(Stuff)
         .run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,22 @@ mod kuvi;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "Bevy Jam 3 🦀".into(),
+                mode: if cfg!(debug_assertions) {
+                    bevy::window::WindowMode::Windowed
+                } else {
+                    bevy::window::WindowMode::BorderlessFullscreen
+                },
+                // Tells wasm to resize the window according to the available canvas
+                fit_canvas_to_parent: true,
+                // Tells wasm not to override default event handling, like F5, Ctrl+R etc.
+                prevent_default_event_handling: false,
+                ..default()
+            }),
+            ..default()
+        }))
         .add_plugin(daivy::Stuff)
         .add_plugin(kuvi::Stuff)
         .run();


### PR DESCRIPTION
- Run game in borderless fullscreen mode on release builds
- Web builds now occupy entirety of the page
- .justfile allow for additional options like `--release`